### PR TITLE
Adds conditional statements and try/except blocks

### DIFF
--- a/persistent_resources_tempest_plugin/tests/api/object_storage/test_cleanup_object_storage_resources.py
+++ b/persistent_resources_tempest_plugin/tests/api/object_storage/test_cleanup_object_storage_resources.py
@@ -8,9 +8,9 @@ from tempest.common.dynamic_creds import DynamicCredentialProvider
 from tempest import config
 from tempest import test
 
-# Version 14 of tempest moves cred_provider library, this allows older  
-# Tempest versions to use this plugin. Older versions may be required   
-# in environments using mirrored packaging repos  
+# Version 14 of tempest moves cred_provider library, this allows older
+# Tempest versions to use this plugin. Older versions may be required
+# in environments using mirrored packaging repos
 try:
     from tempest.lib.common.cred_provider import TestResources
 except ImportError:
@@ -56,7 +56,12 @@ class CleanupObjectStoragePersistentResources(base.BaseObjectTest):
         file_path = os.path.join(test_base_path, 'persistent.resource')
         with open(file_path, 'rb') as f:
             resources = pickle.load(f)
-        cls.containers.extend(resources['containers'])
+        # Hack to use plugin in older version of tempest
+        # in repo locked environment
+        try:
+            cls.containers.extend(resources['containers'])
+        except AttributeError:
+            cls.containers = resources["containers"]
         # Remove the file with the persistent resources
         os.remove(file_path)
 

--- a/persistent_resources_tempest_plugin/tests/api/object_storage/test_create_object_storage_resources.py
+++ b/persistent_resources_tempest_plugin/tests/api/object_storage/test_create_object_storage_resources.py
@@ -31,6 +31,10 @@ class ObjectStoragePersistentResources(base.BaseObjectTest):
         super(ObjectStoragePersistentResources, cls).resource_setup()
         cls.objects = []
         cls.object_data = []
+        # Hack to use plugin in older version of tempest
+        # in repo locked environment
+        if not hasattr(cls, 'containers'):
+            cls.containers = []
 
     @classmethod
     def resource_cleanup(cls):

--- a/persistent_resources_tempest_plugin/tests/api/object_storage/test_validate_object_storage_resources.py
+++ b/persistent_resources_tempest_plugin/tests/api/object_storage/test_validate_object_storage_resources.py
@@ -9,9 +9,9 @@ from tempest import config
 from tempest import test
 from unittest.suite import TestSuite
 
-# Version 14 of tempest moves cred_provider library, this allows older  
-# Tempest versions to use this plugin. Older versions may be required   
-# in environments using mirrored packaging repos  
+# Version 14 of tempest moves cred_provider library, this allows older
+# Tempest versions to use this plugin. Older versions may be required
+# in environments using mirrored packaging repos
 try:
     from tempest.lib.common.cred_provider import TestResources
 except ImportError:
@@ -99,7 +99,12 @@ class VerifyObjectStoragePersistentResources(base.BaseObjectTest):
         object_name = self.resources['objects'][0]
         _, object_list = self.container_client.list_container_contents(
             container)
-        self.assertEqual(object_name, object_list.strip('\n'))
+        if type(object_list) is str:
+            self.assertEqual(object_name, object_list.strip('\n'))
+        elif type(object_list) is list:
+            self.assertEqual(object_name, object_list[0])
+        else:
+            raise TypeError('Unexpected type of object_list: {}'.format(type(object_list)))
 
     @test.attr(type='persistent-verify')
     def test_get_persistent_object(self):


### PR DESCRIPTION
to allow use of this plugin in previous (12.0) version of Tempest.

This previous version is required due to version locked
environment.